### PR TITLE
Removed unecessary node_mode path in scripts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,10 +5,10 @@
   "homepage": "https://github.com/FredericHeem/starhackit",
   "license": "NLPL",
   "scripts": {
-    "start": "./node_modules/.bin/gulp",
+    "start": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "./node_modules/.bin/gulp build",
-    "build": "./node_modules/.bin/gulp build"
+    "postinstall": "gulp build",
+    "build": "gulp build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm resolves node_module and node_module/.bin to the path when you run a script command. 

See https://docs.npmjs.com/misc/scripts#path